### PR TITLE
Hide posts from the future

### DIFF
--- a/blog.js
+++ b/blog.js
@@ -73,9 +73,9 @@ const getAllPosts = async id => {
     posts[i].parent = id;
   }
   
-  /* ::: Sort the posts by date ::: */
-  posts.sort((a,b) => b.date - a.date);
-  
+  /* ::: Sort the posts by date, and filter out future posts ::: */
+  posts = posts.filter((p) => p.date < Date.now()).sort((a,b) => b.date - a.date);
+
   // console.log(posts);
   return posts;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sheet-posting",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Create a blog page and rss feed from a google sheets spreadsheet",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
This should resolve issue #4, as it filters out all posts with a date **equal to or greater than "now"**. This was tested locally using this sheet with a post that shouldn't publish until 2082: https://docs.google.com/spreadsheets/d/1xqNTt2f7iSpC_cKV0JyOe9F1fOP349ewm4r5UKRUXO8/edit#gid=0